### PR TITLE
RUN-3422: fix: do not set null attribute value

### DIFF
--- a/src/main/java/org/rundeck/plugins/nodes/icon/IconNodeEnhancer.java
+++ b/src/main/java/org/rundeck/plugins/nodes/icon/IconNodeEnhancer.java
@@ -8,7 +8,8 @@ import com.dtolabs.rundeck.plugins.util.DescriptionBuilder;
 
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.*;
+import java.util.List;
+import java.util.Properties;
 
 @Plugin(service = "NodeEnhancer", name = IconNodeEnhancer.PROVIDER)
 @PluginDescription(title = "Icon",
@@ -110,8 +111,12 @@ public class IconNodeEnhancer
             && !attributeValue.equals(node.getAttributes().get(attributeName))) {
             return;
         }
-        node.addAttribute("ui:icon:name", iconName);
-        if (iconColor != null && !"".equals(iconColor)) {
+        if (null != iconName && !iconName.isBlank()) {
+            if (iconName.startsWith("glyphicon-") || iconName.startsWith("fa-") || iconName.startsWith("fab-")) {
+                node.addAttribute("ui:icon:name", iconName);
+            }
+        }
+        if (iconColor != null && !iconColor.isBlank()) {
             node.addAttribute("ui:icon:color", iconColor);
         }
         if (iconBadges != null && iconBadges.size() > 0) {
@@ -124,7 +129,9 @@ public class IconNodeEnhancer
                     sb.append(iconBadge);
                 }
             }
-            node.addAttribute("ui:badges", sb.toString());
+            if (sb.length() > 0) {
+                node.addAttribute("ui:badges", sb.toString());
+            }
         }
     }
 

--- a/src/test/groovy/org/rundeck/plugins/nodes/icon/IconNodeEnhancerSpec.groovy
+++ b/src/test/groovy/org/rundeck/plugins/nodes/icon/IconNodeEnhancerSpec.groovy
@@ -1,0 +1,42 @@
+package org.rundeck.plugins.nodes.icon
+
+import com.dtolabs.rundeck.plugins.nodes.IModifiableNodeEntry
+import spock.lang.Specification
+
+class IconNodeEnhancerSpec extends Specification {
+
+    def "test icon enhancement"() {
+        given:
+        def node = Mock(IModifiableNodeEntry) {
+            getAttributes() >> ['key': 'value']
+        }
+        def iconEnhancer = new IconNodeEnhancer()
+        iconEnhancer.attributeName = attributeName
+        iconEnhancer.attributeValue = attributeValue
+        iconEnhancer.iconName = iconName
+        iconEnhancer.iconColor = iconColor
+        iconEnhancer.iconBadges = iconBadges
+        when:
+        iconEnhancer.updateNode('project', node)
+
+        then:
+        (expectName ? 1 : 0) * node.addAttribute('ui:icon:name', expectName)
+        (expectColor ? 1 : 0) * node.addAttribute('ui:icon:color', expectColor)
+        (expectBadges ? 1 : 0) * node.addAttribute('ui:badges', expectBadges)
+        0 * node.addAttribute(_, null)
+
+        where:
+        attributeName | attributeValue | iconName         | iconColor   | iconBadges                  | expectName       | expectColor | expectBadges
+        'key'         | 'value'        | null             | null        | []                          | null             | null        | null
+        'wrongkey'    | 'value'        | 'fa-iconName'    | 'iconColor' | ['fa-badge1', 'fab-badge2'] | null             | null        | null
+        'key'         | 'value'        | null             | null        | ['fa-badge1', 'fab-badge2'] | null             | null        | 'fa-badge1,fab-badge2'
+        'key'         | 'value'        | null             | 'iconColor' | []                          | null             | 'iconColor' | null
+        'key'         | 'value'        | 'fa-test'        | null        | []                          | 'fa-test'        | null        | null
+        'key'         | 'value'        | 'fab-test'       | null        | []                          | 'fab-test'       | null        | null
+        'key'         | 'value'        | 'glyphicon-test' | null        | []                          | 'glyphicon-test' | null        | null
+        'key'         | 'value'        | 'other'          | null        | []                          | null             | null        | null
+        'key'         | 'value'        | 'fa-test'        | 'iconColor' | ['fa-badge1', 'fab-badge2'] | 'fa-test'        | 'iconColor' | 'fa-badge1,fab-badge2'
+        'key'         | 'value'        | 'fa-test'        | 'iconColor' | ['wrong', 'fab-badge2']     | 'fa-test'        | 'iconColor' | 'fab-badge2'
+        'key'         | 'value'        | 'fa-test'        | 'iconColor' | ['glyphicon-x']             | 'fa-test'        | 'iconColor' | 'glyphicon-x'
+    }
+}


### PR DESCRIPTION
if iconName is left blank, the attribute "ui:icon:name" is set to `null` which causes an exception.