### PR TITLE
RUN-3601: CVE-2025-48924 Fix

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -56,8 +56,20 @@ dependencies {
     implementation(libs.rundeckCore) {
         exclude group: "com.google.guava"
     }
+    
+    // Add secure commons-lang3 to provide alternative to vulnerable commons-lang 2.6
+    implementation(libs.commonsLang3)
 
     testImplementation libs.bundles.testLibs
+}
+
+configurations.all {
+    resolutionStrategy {
+        // Replace vulnerable commons-lang with secure commons-lang3
+        dependencySubstitution {
+            substitute module('commons-lang:commons-lang') using module("org.apache.commons:commons-lang3:${libs.versions.commonsLang3.get()}")
+        }
+    }
 }
 
 // In this section you declare where to find the dependencies of your project

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -4,11 +4,14 @@ groovy = "3.0.24"
 rundeckCore = "5.14.0-rc1-20250722"
 nexusPublish = "2.0.0"
 spock = "2.3-groovy-3.0"
+# Security overrides for transitive dependencies
+commonsLang3 = "3.18.0"
 
 [libraries]
 rundeckCore = { group = "org.rundeck", name = "rundeck-core", version.ref = "rundeckCore" }
 groovyAll = { group = "org.codehaus.groovy", name = "groovy-all", version.ref = "groovy" }
 spockCore = { group = "org.spockframework", name = "spock-core", version.ref = "spock" }
+commonsLang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commonsLang3" }
 
 [bundles]
 testLibs = ["groovyAll", "spockCore"]

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -11,7 +11,7 @@ commonsLang3 = "3.18.0"
 rundeckCore = { group = "org.rundeck", name = "rundeck-core", version.ref = "rundeckCore" }
 groovyAll = { group = "org.codehaus.groovy", name = "groovy-all", version.ref = "groovy" }
 spockCore = { group = "org.spockframework", name = "spock-core", version.ref = "spock" }
-commonsLang3 = { module = "org.apache.commons:commons-lang3", version.ref = "commonsLang3" }
+commonsLang3 = { group = "org.apache.commons", name = "commons-lang3", version.ref = "commonsLang3" }
 
 [bundles]
 testLibs = ["groovyAll", "spockCore"]


### PR DESCRIPTION
Mitigates CVE-2025-48924 by upgrading commons-lang to commons-lang3 3.18.0.

**Changes:**
- Added commons-lang3 3.18.0 dependency to libs.versions.toml
- Configured dependency substitution to replace vulnerable commons-lang with secure commons-lang3
- Ensures all transitive dependencies use the secure version

**Security Impact:**
This change addresses the security vulnerability identified in CVE-2025-48924 by replacing the vulnerable commons-lang 2.x library with the secure commons-lang3 3.18.0 version.